### PR TITLE
Fixes for search highlighting

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1155,8 +1155,8 @@ function my_acf_post_id() {
 
 /* search functions */
 function sarnia_highlight_results($text){
-	if(is_search()){
-		$search = get_query_var('s');
+	if(in_the_loop() && is_search()) {
+		$search = preg_quote(get_query_var('s'));
 		$text = preg_replace('/('. $search .')/iu', '<span class="search-result__highlight">$1</span>', $text);
 	}
 


### PR DESCRIPTION
- only highlight if in the loop
- escape user search input before using it to match in the regex

I was going to just use str_ireplace but if you searched for "sarnia", it would turn all highlights into lower case. Wrapping the search input with preg_replace turns a search like ".*" into "\.\*", escaping all the special characters.

Additionally, since we are using the capture group ($1) in the replacement string, we maintain the original capitalization etc from the post.